### PR TITLE
Fix incorrect identifier value condition

### DIFF
--- a/packages/destination-actions/src/destinations/dotdigital/input-fields/contact-identifier.ts
+++ b/packages/destination-actions/src/destinations/dotdigital/input-fields/contact-identifier.ts
@@ -45,10 +45,10 @@ const mobileNumberIdentifier: InputField = {
     }
   },
   depends_on: {
-    conditions: [{ fieldKey: 'channelIdentifier', operator: 'is', value: 'mobile-number' }]
+    conditions: [{ fieldKey: 'channelIdentifier', operator: 'is', value: 'mobileNumber' }]
   },
   required: {
-    conditions: [{ fieldKey: 'channelIdentifier', operator: 'is', value: 'mobile-number' }]
+    conditions: [{ fieldKey: 'channelIdentifier', operator: 'is', value: 'mobileNumber' }]
   }
 }
 


### PR DESCRIPTION
## What's being changed

we have fixed the identifier condition case

## Why it's being changed

The mobile phone number identifier was wrong causing the dotdigital API to reject the request 

## How to review / test this change
- Ensure the payload returns a 200 form Dotdigital.