### PR TITLE
Fix case for mobile identifiers

### DIFF
--- a/packages/destination-actions/src/destinations/dotdigital/input-fields/contact-identifier.ts
+++ b/packages/destination-actions/src/destinations/dotdigital/input-fields/contact-identifier.ts
@@ -9,7 +9,7 @@ const channelIdentifier: InputField = {
   required: true,
   choices: [
     { label: 'Email address', value: 'email' },
-    { label: 'Mobile number', value: 'mobile-number' }
+    { label: 'Mobile number', value: 'mobileNumber' }
   ]
 }
 
@@ -45,10 +45,10 @@ const mobileNumberIdentifier: InputField = {
     }
   },
   depends_on: {
-    conditions: [{ fieldKey: 'channelIdentifier', operator: 'is', value: 'mobile-number' }]
+    conditions: [{ fieldKey: 'channelIdentifier', operator: 'is', value: 'mobileNumber' }]
   },
   required: {
-    conditions: [{ fieldKey: 'channelIdentifier', operator: 'is', value: 'mobile-number' }]
+    conditions: [{ fieldKey: 'channelIdentifier', operator: 'is', value: 'mobileNumber' }]
   }
 }
 


### PR DESCRIPTION
## What's being changed

We have change the identifier value for mobile numbers in the shared input field. 

## Why it's being changed

The mobile phone number identifier was wrong causing the dotdigital API to reject the request 

## How to review / test this change
- Ensure the payload returns a 200 form Dotdigital.