### PR TITLE
Add Resubscribe options

### DIFF
--- a/packages/actions-shared/src/dotdigital/api/resources/dd-contact-api.ts
+++ b/packages/actions-shared/src/dotdigital/api/resources/dd-contact-api.ts
@@ -1,6 +1,6 @@
 import { ModifiedResponse, RequestClient } from '@segment/actions-core'
 import DDApi from '../dd-api'
-import { Contact, ChannelIdentifier, Identifiers, ChannelProperties, UpsertContactJSON, DataFields } from '../types'
+import { Contact, ChannelIdentifier, Identifiers, ResubscribeOptions, ChannelProperties, UpsertContactJSON, DataFields } from '../types'
 
 class DDContactApi extends DDApi {
   constructor(api_host: string, client: RequestClient) {
@@ -36,17 +36,116 @@ class DDContactApi extends DDApi {
 
   /**
    * Creates or updates a contact .
+   * @returns {Promise<Contact>} A promise resolving to the contact data.
+   */
+  public async upsertContact(payload: {
+    channelIdentifier: string
+    emailIdentifier?: string
+    mobileNumberIdentifier?: string
+    emailType?: string
+    optInType?: string
+    updateEmailSubscription?: boolean
+    emailSubscriptionStatus?: string
+    emailResubscribe?: boolean
+    resubscribeWithoutChallengeEmail?: boolean
+    preferredLocale?: string
+    redirectUrlAfterChallenge?: string
+    updateSmsSubscription?: boolean
+    smsSubscriptionStatus?: string
+    listId?: number
+    dataFields?: { [k: string]: unknown }
+  }): Promise<Contact> {
+    const {
+      channelIdentifier,
+      emailIdentifier,
+      mobileNumberIdentifier,
+      emailType = 'html',
+      optInType = 'single',
+      updateEmailSubscription = true,
+      emailSubscriptionStatus = 'subscribed',
+      emailResubscribe = false,
+      resubscribeWithoutChallengeEmail = false,
+      preferredLocale,
+      redirectUrlAfterChallenge,
+      updateSmsSubscription = true,
+      smsSubscriptionStatus = 'subscribed',
+      listId,
+      dataFields
+    } = payload
+
+    const idValue = channelIdentifier === 'email' ? emailIdentifier : mobileNumberIdentifier
+
+    const identifiers: Identifiers = {
+      ...(emailIdentifier && { email: emailIdentifier }),
+      ...(mobileNumberIdentifier && { mobileNumber: mobileNumberIdentifier })
+    }
+
+    const channelProperties: ChannelProperties = {}
+
+    // Email channel properties
+    if (emailIdentifier) {
+      channelProperties.email = {
+        emailType,
+        optInType
+      }
+
+      if (updateEmailSubscription) {
+        if (emailSubscriptionStatus === 'subscribed') {
+          // Only send status if resubscribe is enabled
+          if (emailResubscribe) {
+            channelProperties.email.status = 'subscribed'
+
+            const resubscribeOptions: ResubscribeOptions = {
+              resubscribeWithNoChallenge: resubscribeWithoutChallengeEmail
+            }
+
+            if (!resubscribeWithoutChallengeEmail) {
+              if (preferredLocale) resubscribeOptions.preferredLocale = preferredLocale
+              if (redirectUrlAfterChallenge) resubscribeOptions.redirectUrlAfterChallenge = redirectUrlAfterChallenge
+            }
+
+            channelProperties.email.resubscribeOptions = resubscribeOptions
+          }
+        } else if (emailSubscriptionStatus) {
+          // For unsubscribed/suppressed, always send the status
+          channelProperties.email.status = emailSubscriptionStatus
+        }
+      }
+    }
+
+    // SMS channel properties
+    if (mobileNumberIdentifier && updateSmsSubscription && smsSubscriptionStatus) {
+      channelProperties.sms = {
+        status: smsSubscriptionStatus
+      }
+    }
+
+    const data: UpsertContactJSON = {
+      identifiers,
+      channelProperties,
+      ...(listId && { lists: [listId] }),
+      dataFields: dataFields as DataFields
+    }
+
+    const response: ModifiedResponse<Contact> = await this.patch<Contact, UpsertContactJSON>(
+      `/contacts/v3/${channelIdentifier}/${idValue}?merge-option=overwrite`,
+      data
+    )
+
+    return response.data
+  }
+
+  /**
+   * Unsubscribes a contact .
    * @param {Payload} payload - The event payload.
    * @returns {Promise<Contact>} A promise resolving to the contact data.
    */
-  public async upsertContact(payload: { 
-    channelIdentifier: string, 
-    emailIdentifier?: string, 
-    mobileNumberIdentifier?: string, 
-    listId: number, 
-    dataFields?: {[k: string]: unknown} 
+  public async unsubscribeContact(payload: {
+    channelIdentifier: string
+    emailIdentifier?: string
+    mobileNumberIdentifier?: string
   }): Promise<Contact> {
-    const { channelIdentifier, emailIdentifier, mobileNumberIdentifier, listId, dataFields } = payload
+    const { channelIdentifier, emailIdentifier, mobileNumberIdentifier } = payload
 
     const idValue = channelIdentifier === 'email' ? emailIdentifier : mobileNumberIdentifier
 
@@ -57,22 +156,16 @@ class DDContactApi extends DDApi {
 
     const channelProperties: ChannelProperties = {
       ...(emailIdentifier && {
-        email: {
-          status: 'subscribed',
-          emailType: 'html',
-          optInType: 'single'
-        }
+        email: { status: 'unsubscribed' }
       }),
       ...(mobileNumberIdentifier && {
-        sms: { status: 'subscribed' }
+        sms: { status: 'unsubscribed' }
       })
     }
 
     const data: UpsertContactJSON = {
       identifiers,
-      channelProperties,
-      lists: [listId],
-      dataFields: dataFields as DataFields
+      channelProperties
     }
 
     const response: ModifiedResponse<Contact> = await this.patch<Contact, UpsertContactJSON>(

--- a/packages/actions-shared/src/dotdigital/api/types.ts
+++ b/packages/actions-shared/src/dotdigital/api/types.ts
@@ -40,11 +40,17 @@ export interface DataFields {
   [key: string]: string | number | boolean | null
 }
 
+export interface ResubscribeOptions {
+  resubscribeWithNoChallenge?: boolean
+  preferredLocale?: string
+  redirectUrlAfterChallenge?: string
+}
 export interface ChannelProperties {
   email?: {
-    status: string
-    emailType: string
-    optInType: string
+    status?: string
+    emailType?: string
+    optInType?: string
+    resubscribeOptions?: ResubscribeOptions
   }
   sms?: {
     status: string
@@ -103,7 +109,7 @@ export type ChannelIdentifier = { email: string; 'mobileNumber'?: never } | { 'm
 export interface UpsertContactJSON {
   identifiers: Identifiers
   channelProperties: ChannelProperties
-  lists: number[]
+  lists?: number[]
   dataFields?: DataFields
 }
 

--- a/packages/destination-actions/src/destinations/dotdigital/addContactToList/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/dotdigital/addContactToList/__tests__/index.test.ts
@@ -10,9 +10,8 @@ export const settings = {
   password: 'api_password'
 }
 
-describe('Add Contact To List', () => {
-  it('should add contact to list with email identifier', async () => {
-    // Mock upsertContact function
+describe('Add or Update Contact', () => {
+  it('should add or update contact with email identifier', async () => {
     nock(settings.api_host)
       .patch(`/contacts/v3/email/test@example.com?merge-option=overwrite`)
       .reply(200, { contactId: 123 })
@@ -34,7 +33,7 @@ describe('Add Contact To List', () => {
       }
     }
     await expect(
-      testDestination.testAction('addContactToList', {
+      testDestination.testAction('addOrUpdateContact', {
         event,
         mapping,
         settings
@@ -42,8 +41,7 @@ describe('Add Contact To List', () => {
     ).resolves.not.toThrowError()
   })
 
-  it('should add contact to list with mobile number identifier', async () => {
-    // Mock upsertContact  function
+  it('should add or update contact with mobile number identifier', async () => {
     nock(settings.api_host)
       .patch(`/contacts/v3/mobileNumber/1234567890?merge-option=overwrite`)
       .reply(200, { contactId: 123 })
@@ -66,11 +64,218 @@ describe('Add Contact To List', () => {
     }
 
     await expect(
-      testDestination.testAction('addContactToList', {
+      testDestination.testAction('addOrUpdateContact', {
         event,
         mapping,
         settings
       })
     ).resolves.not.toThrowError()
+  })
+
+  it('should not send email status when resubscribe is false', async () => {
+    nock(settings.api_host)
+      .patch(`/contacts/v3/email/test@example.com?merge-option=overwrite`, (body) => {
+        expect(body.channelProperties.email?.status).toBeUndefined()
+        return true
+      })
+      .reply(200, { contactId: 123 })
+
+    const event = createTestEvent({
+      type: 'identify',
+      context: { traits: { email: 'test@example.com' } }
+    })
+
+    const mapping = {
+      channelIdentifier: 'email',
+      emailIdentifier: { '@path': '$.context.traits.email' },
+      updateEmailSubscription: true,
+      emailSubscriptionStatus: 'subscribed',
+      emailResubscribe: false
+    }
+
+    await testDestination.testAction('addOrUpdateContact', {
+      event,
+      mapping,
+      settings
+    })
+  })
+
+  it('should send subscribed status with resubscribe options when emailResubscribe is true', async () => {
+    nock(settings.api_host)
+      .patch(`/contacts/v3/email/test@example.com?merge-option=overwrite`, (body) => {
+        expect(body.channelProperties.email.status).toBe('subscribed')
+        expect(body.channelProperties.email.resubscribeOptions).toEqual({
+          resubscribeWithNoChallenge: false
+        })
+        return true
+      })
+      .reply(200, { contactId: 123 })
+
+    const event = createTestEvent({
+      type: 'identify',
+      context: { traits: { email: 'test@example.com' } }
+    })
+
+    const mapping = {
+      channelIdentifier: 'email',
+      emailIdentifier: { '@path': '$.context.traits.email' },
+      updateEmailSubscription: true,
+      emailSubscriptionStatus: 'subscribed',
+      emailResubscribe: true,
+      resubscribeWithoutChallengeEmail: false
+    }
+
+    await testDestination.testAction('addOrUpdateContact', {
+      event,
+      mapping,
+      settings
+    })
+  })
+
+  it('should include locale and redirect URL when resubscribe without challenge is false', async () => {
+    nock(settings.api_host)
+      .patch(`/contacts/v3/email/test@example.com?merge-option=overwrite`, (body) => {
+        expect(body.channelProperties.email.resubscribeOptions).toEqual({
+          resubscribeWithNoChallenge: false,
+          preferredLocale: 'en-EN',
+          redirectUrlAfterChallenge: 'https://example.com/welcome'
+        })
+        return true
+      })
+      .reply(200, { contactId: 123 })
+
+    const event = createTestEvent({
+      type: 'identify',
+      context: { traits: { email: 'test@example.com' } }
+    })
+
+    const mapping = {
+      channelIdentifier: 'email',
+      emailIdentifier: { '@path': '$.context.traits.email' },
+      updateEmailSubscription: true,
+      emailSubscriptionStatus: 'subscribed',
+      emailResubscribe: true,
+      resubscribeWithoutChallengeEmail: false,
+      preferredLocale: 'en-EN',
+      redirectUrlAfterChallenge: 'https://example.com/welcome'
+    }
+
+    await testDestination.testAction('addOrUpdateContact', {
+      event,
+      mapping,
+      settings
+    })
+  })
+
+  it('should not include locale and redirect URL when resubscribe without challenge is true', async () => {
+    nock(settings.api_host)
+      .patch(`/contacts/v3/email/test@example.com?merge-option=overwrite`, (body) => {
+        expect(body.channelProperties.email.resubscribeOptions).toEqual({
+          resubscribeWithNoChallenge: true
+        })
+        return true
+      })
+      .reply(200, { contactId: 123 })
+
+    const event = createTestEvent({
+      type: 'identify',
+      context: { traits: { email: 'test@example.com' } }
+    })
+
+    const mapping = {
+      channelIdentifier: 'email',
+      emailIdentifier: { '@path': '$.context.traits.email' },
+      updateEmailSubscription: true,
+      emailSubscriptionStatus: 'subscribed',
+      emailResubscribe: true,
+      resubscribeWithoutChallengeEmail: true
+    }
+
+    await testDestination.testAction('addOrUpdateContact', {
+      event,
+      mapping,
+      settings
+    })
+  })
+
+  it('should send unsubscribed status without resubscribe options', async () => {
+    nock(settings.api_host)
+      .patch(`/contacts/v3/email/test@example.com?merge-option=overwrite`, (body) => {
+        expect(body.channelProperties.email.status).toBe('unsubscribed')
+        expect(body.channelProperties.email.resubscribeOptions).toBeUndefined()
+        return true
+      })
+      .reply(200, { contactId: 123 })
+
+    const event = createTestEvent({
+      type: 'identify',
+      context: { traits: { email: 'test@example.com' } }
+    })
+
+    const mapping = {
+      channelIdentifier: 'email',
+      emailIdentifier: { '@path': '$.context.traits.email' },
+      updateEmailSubscription: true,
+      emailSubscriptionStatus: 'unsubscribed'
+    }
+
+    await testDestination.testAction('addOrUpdateContact', {
+      event,
+      mapping,
+      settings
+    })
+  })
+
+  it('should handle SMS subscription status', async () => {
+    nock(settings.api_host)
+      .patch(`/contacts/v3/mobileNumber/1234567890?merge-option=overwrite`, (body) => {
+        expect(body.channelProperties.sms.status).toBe('subscribed')
+        return true
+      })
+      .reply(200, { contactId: 123 })
+
+    const event = createTestEvent({
+      type: 'identify',
+      context: { traits: { phone: '1234567890' } }
+    })
+
+    const mapping = {
+      channelIdentifier: 'mobileNumber',
+      mobileNumberIdentifier: { '@path': '$.context.traits.phone' },
+      updateSmsSubscription: true,
+      smsSubscriptionStatus: 'subscribed'
+    }
+
+    await testDestination.testAction('addOrUpdateContact', {
+      event,
+      mapping,
+      settings
+    })
+  })
+
+  it('should not send SMS status when updateSmsSubscription is false', async () => {
+    nock(settings.api_host)
+      .patch(`/contacts/v3/mobileNumber/1234567890?merge-option=overwrite`, (body) => {
+        expect(body.channelProperties.sms).toBeUndefined()
+        return true
+      })
+      .reply(200, { contactId: 123 })
+
+    const event = createTestEvent({
+      type: 'identify',
+      context: { traits: { phone: '1234567890' } }
+    })
+
+    const mapping = {
+      channelIdentifier: 'mobileNumber',
+      mobileNumberIdentifier: { '@path': '$.context.traits.phone' },
+      updateSmsSubscription: false
+    }
+
+    await testDestination.testAction('addOrUpdateContact', {
+      event,
+      mapping,
+      settings
+    })
   })
 })

--- a/packages/destination-actions/src/destinations/dotdigital/addContactToList/generated-types.ts
+++ b/packages/destination-actions/src/destinations/dotdigital/addContactToList/generated-types.ts
@@ -14,9 +14,49 @@ export interface Payload {
    */
   mobileNumberIdentifier?: string
   /**
+   * The type of email the contact prefers to receive.
+   */
+  emailType?: string
+  /**
+   * The type of opt-in used for this contact. [Learn more](https://support.dotdigital.com/en/articles/8198810-email-opt-in-types)
+   */
+  optInType?: string
+  /**
+   * Choose whether to update the email subscription status.
+   */
+  updateEmailSubscription?: boolean
+  /**
+   * The subscription status for the email channel.
+   */
+  emailSubscriptionStatus?: string
+  /**
+   * When Yes, the action will send a "subscribed" status in the API call for email.
+   */
+  emailResubscribe?: boolean
+  /**
+   * If Yes, no resubscription confirmation email will be sent.
+   */
+  resubscribeWithoutChallengeEmail?: boolean
+  /**
+   * Choose the language that you would like the resubscribe request email to be sent in.
+   */
+  preferredLocale?: string
+  /**
+   * The URL you would like to redirect challenged contacts to after they have completed their resubscription.
+   */
+  redirectUrlAfterChallenge?: string
+  /**
+   * Choose whether to update the SMS subscription status.
+   */
+  updateSmsSubscription?: boolean
+  /**
+   * The subscription status for the SMS channel.
+   */
+  smsSubscriptionStatus?: string
+  /**
    * The list to add the contact to.
    */
-  listId: number
+  listId?: number
   /**
    * An object containing key/value pairs for data fields assigned to this Contact. Custom Data Fields must already be defined in Dotdigital.
    */

--- a/packages/destination-actions/src/destinations/dotdigital/addContactToList/index.ts
+++ b/packages/destination-actions/src/destinations/dotdigital/addContactToList/index.ts
@@ -2,19 +2,175 @@ import { ActionDefinition, DynamicFieldResponse, RequestClient } from '@segment/
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { DDContactApi, DDListsApi, DDDataFieldsApi } from '@segment/actions-shared'
-import { contactIdentifier } from '../input-fields'
+import { channelIdentifier, emailIdentifier, mobileNumberIdentifier } from '../input-fields'
 
 const action: ActionDefinition<Settings, Payload> = {
-  title: 'Add Contact to List',
-  description: 'Adds a contact to a list.',
-  defaultSubscription: 'type = "track" and event = "Add Contact to List"',
+  title: 'Add or Update Contact',
+  description: 'Adds or updates a contact.',
+  defaultSubscription: 'type = "track" and event = "Add or Update Contact"',
   fields: {
-    ...contactIdentifier,
+    channelIdentifier,
+    emailIdentifier,
+    mobileNumberIdentifier,
+    emailType: {
+      label: 'Email Type',
+      description: 'The type of email the contact prefers to receive.',
+      type: 'string',
+      choices: [
+        { label: 'HTML', value: 'html' },
+        { label: 'Plain Text', value: 'plainText' }
+      ],
+      default: 'html',
+      depends_on: {
+        conditions: [{ fieldKey: 'channelIdentifier', operator: 'is', value: 'email' }]
+      },
+      required: false
+    },
+    optInType: {
+      label: 'Opt-in Type',
+      description: 'The type of opt-in used for this contact. [Learn more](https://support.dotdigital.com/en/articles/8198810-email-opt-in-types)',
+      type: 'string',
+      choices: [
+        { label: 'Unknown', value: 'unknown' },
+        { label: 'Single', value: 'single' },
+        { label: 'Double', value: 'double' },
+        { label: 'Verified Double', value: 'verifiedDouble' }
+      ],
+      default: 'single',
+      depends_on: {
+        conditions: [{ fieldKey: 'channelIdentifier', operator: 'is', value: 'email' }]
+      },
+      required: false
+    },
+    updateEmailSubscription: {
+      label: 'Update Email Subscription Status',
+      description: 'Choose whether to update the email subscription status.',
+      type: 'boolean',
+      default: true,
+      depends_on: {
+        conditions: [{ fieldKey: 'channelIdentifier', operator: 'is', value: 'email' }]
+      },
+      required: false
+    },
+    emailSubscriptionStatus: {
+      label: 'Email Subscription Status',
+      description: 'The subscription status for the email channel.',
+      type: 'string',
+      choices: [
+        { label: 'Subscribed', value: 'subscribed' },
+        { label: 'Unsubscribed', value: 'unsubscribed' },
+        { label: 'Suppressed', value: 'suppressed' }
+      ],
+      default: 'subscribed',
+      depends_on: {
+        conditions: [{ fieldKey: 'updateEmailSubscription', operator: 'is', value: true }]
+      },
+      required: false
+    },
+    emailResubscribe: {
+      label: 'Resubscribe if Previously Unsubscribed',
+      description: 'When Yes, the action will send a "subscribed" status in the API call for email.',
+      type: 'boolean',
+      default: true,
+      depends_on: {
+        conditions: [
+          { fieldKey: 'updateEmailSubscription', operator: 'is', value: true },
+          { fieldKey: 'emailSubscriptionStatus', operator: 'is', value: 'subscribed' }
+        ],
+        match: 'all'
+      },
+      required: false
+    },
+    resubscribeWithoutChallengeEmail: {
+      label: 'Resubscribe Without Challenge Email',
+      description: 'If Yes, no resubscription confirmation email will be sent.',
+      type: 'boolean',
+      default: false,
+      depends_on: {
+        conditions: [
+          { fieldKey: 'emailResubscribe', operator: 'is', value: true }
+        ]
+      },
+      required: false
+    },
+    preferredLocale: {
+      label: 'Preferred Language',
+      description: 'Choose the language that you would like the resubscribe request email to be sent in.',
+      choices: [
+        { label: 'cs-CS', value: 'cs-CS' },
+        { label: 'da-DA', value: 'da-DA' },
+        { label: 'de-DE', value: 'de-DE' },
+        { label: 'el-EL', value: 'el-EL' },
+        { label: 'en-EN', value: 'en-EN' },
+        { label: 'es-ES', value: 'es-ES' },
+        { label: 'es', value: 'es' },
+        { label: 'fi-FI', value: 'fi-FI' },
+        { label: 'fr-FR', value: 'fr-FR' },
+        { label: 'hu-HU', value: 'hu-HU' },
+        { label: 'it-IT', value: 'it-IT' },
+        { label: 'nl-NL', value: 'nl-NL' },
+        { label: 'nb-NO', value: 'nb-NO' },
+        { label: 'pl-PL', value: 'pl-PL' },
+        { label: 'pt-PT', value: 'pt-PT' },
+        { label: 'ru-RU', value: 'ru-RU' },
+        { label: 'se-SE', value: 'se-SE' },
+        { label: 'sk-SK', value: 'sk-SK' },
+        { label: 'tr-TR', value: 'tr-TR' },
+        { label: 'zh-CN', value: 'zh-CN' }
+      ],
+      type: 'string',
+      depends_on: {
+        conditions: [
+          { fieldKey: 'emailResubscribe', operator: 'is', value: true },
+          { fieldKey: 'resubscribeWithoutChallengeEmail', operator: 'is', value: false }
+        ],
+        match: 'all'
+      },
+      required: false
+    },
+    redirectUrlAfterChallenge: {
+      label: 'Redirect URL',
+      description: 'The URL you would like to redirect challenged contacts to after they have completed their resubscription.',
+      type: 'string',
+      depends_on: {
+        conditions: [
+          { fieldKey: 'emailResubscribe', operator: 'is', value: true },
+          { fieldKey: 'resubscribeWithoutChallengeEmail', operator: 'is', value: false }
+        ],
+        match: 'all'
+      },
+      required: false
+    },
+    updateSmsSubscription: {
+      label: 'Update SMS Subscription Status',
+      description: 'Choose whether to update the SMS subscription status.',
+      type: 'boolean',
+      default: true,
+      depends_on: {
+        conditions: [{ fieldKey: 'channelIdentifier', operator: 'is', value: 'mobileNumber' }]
+      },
+      required: false
+    },
+    smsSubscriptionStatus: {
+      label: 'SMS Subscription Status',
+      description: 'The subscription status for the SMS channel.',
+      type: 'string',
+      choices: [
+        { label: 'Subscribed', value: 'subscribed' },
+        { label: 'Unsubscribed', value: 'unsubscribed' },
+        { label: 'Suppressed', value: 'suppressed' }
+      ],
+      default: 'subscribed',
+      depends_on: {
+        conditions: [{ fieldKey: 'updateSmsSubscription', operator: 'is', value: true }]
+      },
+      required: false
+    },
     listId: {
       label: 'List',
       description: `The list to add the contact to.`,
       type: 'number',
-      required: true,
+      required: false,
       allowNull: false,
       disabledInputMethods: ['literal', 'variable', 'function', 'freeform', 'enrichment'],
       dynamic: true

--- a/packages/destination-actions/src/destinations/dotdigital/enrolContact/index.ts
+++ b/packages/destination-actions/src/destinations/dotdigital/enrolContact/index.ts
@@ -1,7 +1,7 @@
 import { ActionDefinition, RequestClient, DynamicFieldResponse, PayloadValidationError } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { contactIdentifier } from '../input-fields'
+import { channelIdentifier, emailIdentifier, mobileNumberIdentifier } from '../input-fields'
 import { DDEnrolmentApi, DDContactApi, ChannelIdentifier, Identifiers } from '@segment/actions-shared'
 
 const action: ActionDefinition<Settings, Payload> = {
@@ -9,7 +9,9 @@ const action: ActionDefinition<Settings, Payload> = {
   description: 'Creates a program enrolment.',
   defaultSubscription: 'type = "track" and event = "Enrol Contact to Program"',
   fields: {
-    ...contactIdentifier,
+    channelIdentifier,
+    emailIdentifier,
+    mobileNumberIdentifier,
     programId: {
       label: 'Program',
       description: `List of active programs`,

--- a/packages/destination-actions/src/destinations/dotdigital/input-fields/contact-identifier.ts
+++ b/packages/destination-actions/src/destinations/dotdigital/input-fields/contact-identifier.ts
@@ -1,7 +1,6 @@
-import { ContactIdentifier } from './types'
 import { InputField } from '@segment/actions-core'
 
-const channelIdentifier: InputField = {
+export const channelIdentifier: InputField = {
   label: 'Contact Identifier type',
   description: 'Select the field to identify contacts.',
   type: 'string',
@@ -13,7 +12,7 @@ const channelIdentifier: InputField = {
   ]
 }
 
-const emailIdentifier: InputField = {
+export const emailIdentifier: InputField = {
   label: 'Email Address',
   description: "The Contact's email address.",
   type: 'string',
@@ -33,7 +32,7 @@ const emailIdentifier: InputField = {
   }
 }
 
-const mobileNumberIdentifier: InputField = {
+export const mobileNumberIdentifier: InputField = {
   label: 'Mobile Number',
   description: "The Contact's mobile number.",
   type: 'string',
@@ -50,10 +49,4 @@ const mobileNumberIdentifier: InputField = {
   required: {
     conditions: [{ fieldKey: 'channelIdentifier', operator: 'is', value: 'mobileNumber' }]
   }
-}
-
-export const contactIdentifier: ContactIdentifier = {
-  channelIdentifier,
-  emailIdentifier,
-  mobileNumberIdentifier
 }

--- a/packages/destination-actions/src/destinations/dotdigital/input-fields/index.ts
+++ b/packages/destination-actions/src/destinations/dotdigital/input-fields/index.ts
@@ -1,1 +1,1 @@
-export { contactIdentifier } from './contact-identifier'
+export { channelIdentifier, emailIdentifier, mobileNumberIdentifier } from './contact-identifier'

--- a/packages/destination-actions/src/destinations/dotdigital/input-fields/types.ts
+++ b/packages/destination-actions/src/destinations/dotdigital/input-fields/types.ts
@@ -1,7 +1,0 @@
-import { InputField } from '@segment/actions-core'
-
-export interface ContactIdentifier {
-  channelIdentifier: InputField
-  emailIdentifier: InputField
-  mobileNumberIdentifier: InputField
-}

--- a/packages/destination-actions/src/destinations/dotdigital/removeContactFromList/index.ts
+++ b/packages/destination-actions/src/destinations/dotdigital/removeContactFromList/index.ts
@@ -2,14 +2,16 @@ import { ActionDefinition, DynamicFieldResponse, RequestClient } from '@segment/
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { DDContactApi, DDListsApi } from '@segment/actions-shared'
-import { contactIdentifier } from '../input-fields'
+import { channelIdentifier, emailIdentifier, mobileNumberIdentifier } from '../input-fields'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Remove Contact from List',
   description: 'Removes a Contact from a List.',
   defaultSubscription: 'type = "track" and event = "Remove Contact from List"',
   fields: {
-    ...contactIdentifier,
+    channelIdentifier,
+    emailIdentifier,
+    mobileNumberIdentifier,
     listId: {
       label: 'List',
       description: `The List to remove the Contact from.`,


### PR DESCRIPTION
### What's being changed
- Renamed Add Contact to List to Add or Update Contact
- Added resubscribe options to Add or Update Contact
- Updated Contact API to use new input parameters

### Why it's being changed
We need an option to resubscribe contacts and allow updates to contacts without affecting their subscription status.

### How to review / test this change

- Unsubscribe a contact
- bin/run serve
- Use addOrUpdateContact with all resubscribe options filled out
- Verify contact is subscribed with the selected resubscription options
- yarn eslint packages/destination-actions/src/destinations/dotdigital
- yarn cloud test --testPathPattern=packages/destination-actions/src/destinations/dotdigital